### PR TITLE
Feature/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,13 @@ Python Guerrillamail
 ====================
 
 Python Guerrillamail is a Python client API and command line interface for
-interacting with a `Guerrillamail`_ temporary email server.
+interacting with a `Guerrillamail` temporary email server.
 
-.. image:: https://travis-ci.org/ncjones/python-guerrillamail.svg?branch=master
-    :target: https://travis-ci.org/ncjones/python-guerrillamail
-    :alt: Build Status
-
+This package was forked from `ncjones/python-guerrillamail` and builds by adding functionality for forgetting an address from the session as well as an additional client function for deleted individual emails via their `guid`. 
 
 Installation
 ------------
-
-.. code-block:: sh
-
-    pip install python-guerrillamail
+     pip install https://github.com/samjtozer/python-guerrillamail.git
 
 
 Example Usage
@@ -23,20 +17,21 @@ Example Usage
 Create session using auto-assigned email address, print email address and print
 id of first message in inbox:
 
-.. code-block:: python
-
     from guerrillamail import GuerrillaMailSession
     session = GuerrillaMailSession()
     print session.get_session_state()['email_address']
     print session.get_email_list()[0].guid
 
 
+You can now delete an email by:
+
+    session.delete_email(session.get_email_list()[0].guid)
+
 Example CLI Usage
 -----------------
 
 Set email address:
 
-.. code-block::
 
     $ guerrillamail setaddr john.doe
     $ guerrillamail info
@@ -44,8 +39,6 @@ Set email address:
 
 
 List inbox contents:
-
-.. code-block::
 
     $ guerrillamail list
     (*) 48859781  23:45:27+00:00  spam@example.com
@@ -59,8 +52,6 @@ List inbox contents:
 
 
 Read email message:
-
-.. code-block::
 
     $ guerrillamail get 48859781
     From: spam@example.com
@@ -79,8 +70,6 @@ property when constructing a GuerrillaMailSession instance. When using the CLI
 the ``base_url`` property can be defined in the ``~/.guerrillamail`` JSON
 config file, for example:
 
-.. code-block:: json
-
     {
         "base_url": "https://api.guerrillamail.com"
     }
@@ -92,4 +81,4 @@ License
 Python Guerrilla Mail is free software, licensed under the GPLv3.
 
 
-.. _Guerrillamail: https://www.guerrillamail.com/
+Guerrillamail: https://www.guerrillamail.com/

--- a/guerrillamail.py
+++ b/guerrillamail.py
@@ -199,13 +199,16 @@ class GuerrillaMailClient(object):
         self.base_url = base_url
         self.client_ip = client_ip
 
-    def _do_request(self, session_id, **kwargs):
+    def _do_request(self, session_id, parameters):
         url = self.base_url + '/ajax.php'
-        kwargs['ip'] = self.client_ip
+        parameters['ip'] = self.client_ip
         if session_id is not None:
-            kwargs['sid_token'] = session_id
-        response = requests.get(url, params=kwargs)
-        print("response text " + response.text) 
+            parameters['sid_token'] = session_id
+        
+        # Mitigate funky url encoding 
+        parameters_str = "&".join("%s=%s" % (k,v) for k,v in parameters.items())
+        response = requests.get(url, params=parameters_str)
+        print(response.url) 
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
@@ -218,28 +221,33 @@ class GuerrillaMailClient(object):
         return data
 
     def get_email_address(self, session_id=None):
-        return self._do_request(session_id, f='get_email_address')
+        parameters = { 'f': 'get_email_address'} 
+        return self._do_request(session_id, parameters)
 
     def get_email_list(self, session_id, offset=0):
         if session_id is None:
             raise ValueError('session_id is None')
-        return self._do_request(session_id, f='get_email_list', offset=offset)
+        parameters = { 'offset': offset, 'f': 'get_email_list' }
+        return self._do_request(session_id, parameters=parameters)
 
     def get_email(self, email_id, session_id=None):
-        response_data = self._do_request(session_id, f='fetch_email', email_id=email_id)
-        print("response data " + response_data)
+        parameters = { 'email_id': email_id, 'f': 'fetch_email' }
+        response_data = self._do_request(session_id, parameters=parameters)
         if not response_data:
             raise GuerrillaMailException('Not found: ' + str(email_id))
         return response_data
 
     def set_email_address(self, address_local_part, session_id=None):
-        return self._do_request(session_id, f='set_email_user', email_user=address_local_part)
+        parameters = { 'email_user': address_local_part, 'f': 'set_email_user' }
+        return self._do_request(session_id, parameters=parameters)
 
     def del_email(self, email_idx, session_id=None):
-        return self._do_request(session_id, f='del_email', email_ids=email_idx) 
+        parameters = { 'email_ids%5B%5D' : email_idx, 'f': 'del_email' }
+        return self._do_request(session_id, parameters=parameters) 
 
     def forget_me(self, email_address, session_id=None):
-        return self._do_request(session_id, f='forget_me', email_addr=email_address)
+        parameters = { 'email_addr': email_address, 'f': 'forget_me' } 
+        return self._do_request(session_id, parameters=parameters)
 
 
 SETTINGS_FILE = '~/.guerrillamail'


### PR DESCRIPTION
This feature branch adds an additional method to session client to allow users to explicitly delete invididual emails from Guerilla servers pre session expiration (at which time they are automatically deleted anyway).

Why? Added security. 